### PR TITLE
fix typo for nuget installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Easily create disposable databases that will make your integration tests a breez
 
 Install `ThrowawayDb` from Nuget
 ```
-dotent add package ThrowawayDb
+dotnet add package ThrowawayDb
 ```
 Use from your code
 ```csharp


### PR DESCRIPTION
`dotent` -> `dotnet`