### PR TITLE
Add a snapshot functionality for SQL server

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,8 @@ public static void Main(string[] args)
         // - Seed the database with data
         // - Execute your code against this database
 
-        using (var connection = new SqlConnection(database.ConnectionString))
+        using (var connection = database.OpenConnection())
         {
-            connection.Open();
             using (var cmd = new SqlCommand("SELECT 1", connection))
             {
                 var result = Convert.ToInt32(cmd.ExecuteScalar());
@@ -57,6 +56,17 @@ ThrowawayDatabase.Create(connectionString: "Data Source=localhost\\SQLEXPRESS;In
 
 // Specify a custom database prefix, otherwise it just uses ThrowawayDb
 ThrowawayDatabase.FromLocalInstance("localhost\\SQLEXPRESS", "dbprefix_")
+```
+
+You can create a snapshot of the database and restore it at a later point:
+```cs
+using var database = ThrowawayDatabase.FromLocalInstance("localhost\\SQLEXPRESS");
+
+// execute necessary actions before initialising a snapshot
+database.CreateSnapshot();
+
+// execute some other actions which modify the database
+database.RestoreSnapshot();
 ```
 
 ## Using PostgreSQL server

--- a/src/ThrowawayDb/SqlConnectionExtensions.cs
+++ b/src/ThrowawayDb/SqlConnectionExtensions.cs
@@ -1,0 +1,16 @@
+﻿using System.Data.SqlClient;
+
+namespace ThrowawayDb
+{
+	internal static class SqlConnectionExtensions
+	{
+		internal static void TerminateDatabaseConnections(this SqlConnection @this, string databaseName)
+		{
+			var cmdText = $"ALTER DATABASE {databaseName} SET SINGLE_USER WITH ROLLBACK IMMEDIATE";
+			using (var cmd = new SqlCommand(cmdText, @this))
+			{
+				cmd.ExecuteNonQuery();
+			}
+		}
+	}
+}

--- a/src/ThrowawayDb/ThrowawayDatabase.cs
+++ b/src/ThrowawayDb/ThrowawayDatabase.cs
@@ -39,22 +39,23 @@ namespace ThrowawayDb
 	        {
 		        connection.Open();
 
-		        var resetActiveSessions = $"ALTER DATABASE {Name} SET SINGLE_USER WITH ROLLBACK IMMEDIATE;";
-
-		        using (var cmd = new SqlCommand(resetActiveSessions, connection))
+		        var cmdText = $"ALTER DATABASE {Name} SET SINGLE_USER WITH ROLLBACK IMMEDIATE;";
+		        using (var cmd = new SqlCommand(cmdText, connection))
 		        {
 			        cmd.ExecuteNonQuery();
                 }
 
 		        if (IsSnapshotCreated())
 		        {
-			        using (var cmd = new SqlCommand($"DROP DATABASE [{_snapshotName}]"))
+			        cmdText = $"DROP DATABASE [{_snapshotName}]";
+                    using (var cmd = new SqlCommand(cmdText, connection))
 			        {
 				        cmd.ExecuteNonQuery();
 			        }
 		        }
 
-		        using (var cmd = new SqlCommand($"DROP DATABASE {Name}", connection))
+		        cmdText = $"DROP DATABASE {Name}";
+                using (var cmd = new SqlCommand(cmdText, connection))
 		        {
 			        cmd.ExecuteNonQuery();
                 }

--- a/src/ThrowawayDb/ThrowawayDatabase.cs
+++ b/src/ThrowawayDb/ThrowawayDatabase.cs
@@ -219,6 +219,10 @@ namespace ThrowawayDb
             return database;
         }
 
+        /// <summary>
+        /// Creates a new snapshot of the <see cref="ThrowawayDatabase"/> in case there is no snapshot created.<br/>
+        /// Does nothing if a snapshot has already been created.
+        /// </summary>
         public void CreateSnapshot()
         {
             if (IsSnapshotCreated())
@@ -252,6 +256,10 @@ namespace ThrowawayDb
             }
         }
 
+        /// <summary>
+        /// Restores a snapshot of the <see cref="ThrowawayDatabase"/> in case the snapshot has been previously created.<br/>
+        /// Does nothing if a snapshot has not been created.
+        /// </summary>
         public void RestoreSnapshot()
         {
             if (!IsSnapshotCreated())

--- a/src/ThrowawayDb/ThrowawayDatabase.cs
+++ b/src/ThrowawayDb/ThrowawayDatabase.cs
@@ -14,17 +14,15 @@ namespace ThrowawayDb
         private string _snapshotName;
 
         /// <summary>Returns the connection string of the database that was created</summary>
-        public string ConnectionString { get; internal set; }
+        public string ConnectionString { get; }
         /// <summary>Returns the name of the database that was created</summary>
-        public string Name { get; internal set; }
+        public string Name { get; }
 
         private ThrowawayDatabase(string originalConnectionString, string databaseNamePrefix)
         {
             // Default constructor is private
             _originalConnectionString = originalConnectionString;
-            var (derivedConnectionString, databaseName) = DeriveThrowawayConnectionString(originalConnectionString, databaseNamePrefix);
-            ConnectionString = derivedConnectionString;
-            Name = databaseName;
+            (ConnectionString, Name) = DeriveThrowawayConnectionString(originalConnectionString, databaseNamePrefix);
         }
 
         private bool IsSnapshotCreated() =>

--- a/src/ThrowawayDb/ThrowawayDatabase.cs
+++ b/src/ThrowawayDb/ThrowawayDatabase.cs
@@ -4,7 +4,7 @@ using System.Diagnostics;
 using System.IO;
 
 namespace ThrowawayDb
-{
+{ 
 	public class ThrowawayDatabase : IDisposable
     {
 	    private const string DefaultDatabaseNamePrefix = "ThrowawayDb";
@@ -28,7 +28,7 @@ namespace ThrowawayDb
         }
 
         private bool IsSnapshotCreated() =>
-	        !string.IsNullOrEmpty(_snapshotName);
+	        _databaseCreated && !string.IsNullOrEmpty(_snapshotName);
 
         private void DropDatabaseIfCreated()
         {

--- a/src/ThrowawayDb/ThrowawayDatabase.cs
+++ b/src/ThrowawayDb/ThrowawayDatabase.cs
@@ -6,13 +6,16 @@ namespace ThrowawayDb
 {
 	public class ThrowawayDatabase : IDisposable
     {
+	    private const string defaultDatabaseNamePrefix = "ThrowawayDb";
+
+	    private readonly string originalConnectionString;
+	    private bool databaseCreated;
+	    private string snapshotName;
+
         /// <summary>Returns the connection string of the database that was created</summary>
         public string ConnectionString { get; internal set; }
         /// <summary>Returns the name of the database that was created</summary>
         public string Name { get; internal set; }
-        private bool databaseCreated;
-        private readonly string originalConnectionString;
-        private const string defaultDatabaseNamePrefix = "ThrowawayDb";
 
         private ThrowawayDatabase(string originalConnectionString, string databaseNamePrefix)
         {
@@ -38,6 +41,14 @@ namespace ThrowawayDb
 		        {
 			        cmd.ExecuteNonQuery();
                 }
+
+		        if (!string.IsNullOrEmpty(snapshotName))
+		        {
+			        using (var cmd = new SqlCommand($"DROP DATABASE [{snapshotName}]"))
+			        {
+				        cmd.ExecuteNonQuery();
+			        }
+		        }
 
 		        using (var cmd = new SqlCommand($"DROP DATABASE {Name}", connection))
 		        {

--- a/src/ThrowawayDb/ThrowawayDatabaseExtensions.cs
+++ b/src/ThrowawayDb/ThrowawayDatabaseExtensions.cs
@@ -6,6 +6,11 @@ namespace ThrowawayDb
 {
 	public static class ThrowawayDatabaseExtensions
 	{
+		/// <summary>
+		/// Opens an SQL connection with an instance of the created <see cref="ThrowawayDatabase"/>.
+		/// </summary>
+		/// <param name="this">An instance of <see cref="ThrowawayDatabase"/></param>
+		/// <returns>A new instance of the SQL connection</returns>
 		public static SqlConnection OpenConnection(this ThrowawayDatabase @this)
 		{
 			var connection = new SqlConnection(@this.ConnectionString);
@@ -14,6 +19,12 @@ namespace ThrowawayDb
 			return connection;
 		}
 
+		/// <summary>
+		/// Opens an SQL connection with an instance of the created <see cref="ThrowawayDatabase"/>.
+		/// </summary>
+		/// <param name="this">An instance of <see cref="ThrowawayDatabase"/></param>
+		/// <param name="cancellationToken">A <see cref="CancellationToken"/> for opening the SQL connection task</param>
+		/// <returns>Task representing an asynchronous operation</returns>
 		public static async Task<SqlConnection> OpenConnectionAsync(this ThrowawayDatabase @this, CancellationToken cancellationToken = default)
 		{
 			var connection = new SqlConnection(@this.ConnectionString);

--- a/src/ThrowawayDb/ThrowawayDatabaseExtensions.cs
+++ b/src/ThrowawayDb/ThrowawayDatabaseExtensions.cs
@@ -1,0 +1,27 @@
+using System.Data.SqlClient;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ThrowawayDb
+{
+	public static class ThrowawayDatabaseExtensions
+	{
+		public static SqlConnection OpenConnection(this ThrowawayDatabase @this)
+		{
+			var connection = new SqlConnection(@this.ConnectionString);
+			connection.Open();
+
+			return connection;
+		}
+
+		public static async Task<SqlConnection> OpenConnectionAsync(this ThrowawayDatabase @this, CancellationToken cancellationToken = default)
+		{
+			var connection = new SqlConnection(@this.ConnectionString);
+
+			await connection.OpenAsync(cancellationToken)
+				.ConfigureAwait(false);
+
+			return connection;
+		}
+	}
+}

--- a/tests/ThrowawayDb/Program.cs
+++ b/tests/ThrowawayDb/Program.cs
@@ -1,44 +1,78 @@
 ﻿using System;
 using System.Data.SqlClient;
+using FluentAssertions;
 using ThrowawayDb;
 
 namespace tests
 {
 	internal class Program
-    {
-		private const string ConnectionString = "localhost\\SQLEXPRESS";
+	{
+		private const string LocalInstanceName = "localhost\\SQLEXPRESS";
+
+		private static ThrowawayDatabase CreateFixture() =>
+			ThrowawayDatabase.FromLocalInstance(LocalInstanceName);
 
 		private static void Main(string[] args)
-        {
-            var arguments = string.Join(", ", args);
-            Console.WriteLine($"Arguments [{arguments}]");
+		{
+			var arguments = string.Join(", ", args);
+			Console.WriteLine($"Arguments [{arguments}]");
 
-            var testCases = new Action<ThrowawayDatabase>[]
-            {
-	            TestDatabaseCreation
-            };
+			var testCases = new Action[]
+			{
+				CreateDatabase
+			};
 
-            using var fixture = ThrowawayDatabase.FromLocalInstance(ConnectionString);
+			for (var i = 0; i < testCases.Length; i++)
+			{
+				Console.WriteLine("Running test #{0}: {1}", i + 1, testCases[i].Method.Name);
+				testCases[i]();
 
-            for (var i = 0; i < testCases.Length; i++)
-            {
-	            Console.WriteLine("Running test #{0}: {1}", i + 1, testCases[i].Method.Name);
-	            testCases[i](fixture);
-            }
-        }
+				Console.WriteLine();
+			}
+		}
 
-	    private static void TestDatabaseCreation(ThrowawayDatabase fixture)
-	    {
-		    Console.WriteLine($"Created database {fixture.Name}");
-		    
-		    // Apply migrations / seed data if necessary
-		    // execute code against this newly generated database
-		    using var connection = new SqlConnection(fixture.ConnectionString);
-		    connection.Open();
-		    
-		    using var cmd = new SqlCommand("SELECT 1", connection);
-		    var result = Convert.ToInt32(cmd.ExecuteScalar());
-		    Console.WriteLine(result); // prints 1
-	    }
-    }
+		private static void CreateDatabase()
+		{
+			string databaseName;
+
+			using (var fixture = CreateFixture())
+			{
+				databaseName = fixture.Name;
+				Console.WriteLine($"Created database {fixture.Name}");
+
+				CheckDatabaseExists(databaseName)
+					.Should()
+					.BeTrue();
+
+				// Apply migrations / seed data if necessary
+				// execute code against this newly generated database
+				using var connection = new SqlConnection(fixture.ConnectionString);
+				connection.Open();
+
+				using var cmd = new SqlCommand("SELECT 1", connection);
+				var result = Convert.ToInt32(cmd.ExecuteScalar());
+				Console.WriteLine(result); // prints 1
+
+				result
+					.Should()
+					.Be(1);
+			}
+
+			CheckDatabaseExists(databaseName)
+				.Should()
+				.BeFalse();
+
+			static bool CheckDatabaseExists(string name)
+			{
+				using var connection = new SqlConnection($"Data Source={LocalInstanceName};Initial Catalog=master;Integrated Security=True;");
+				connection.Open();
+
+				using var cmd = new SqlCommand($"SELECT CASE WHEN DB_ID(@{nameof(name)}) IS NULL THEN 0 ELSE 1 END", connection);
+				cmd.Parameters.AddWithValue(nameof(name), name);
+
+				var result = cmd.ExecuteScalar();
+				return Convert.ToInt32(result) == 1;
+			}
+		}
+	}
 }

--- a/tests/ThrowawayDb/Program.cs
+++ b/tests/ThrowawayDb/Program.cs
@@ -4,28 +4,41 @@ using ThrowawayDb;
 
 namespace tests
 {
-    class Program
+	internal class Program
     {
-        static void Main(string[] args)
+		private const string ConnectionString = "localhost\\SQLEXPRESS";
+
+		private static void Main(string[] args)
         {
-            var arguments = String.Join(", ", args);
+            var arguments = string.Join(", ", args);
             Console.WriteLine($"Arguments [{arguments}]");
 
-            using (var database = ThrowawayDatabase.FromLocalInstance("localhost\\SQLEXPRESS"))
+            var testCases = new Action<ThrowawayDatabase>[]
             {
-                Console.WriteLine($"Created database {database.Name}");
-                // Apply migrations / seed data if necessary
-                // execute code against this newly generated database
-                using (var connection = new SqlConnection(database.ConnectionString))
-                {
-                    connection.Open();
-                    using (var cmd = new SqlCommand("SELECT 1", connection))
-                    {
-                        var result = Convert.ToInt32(cmd.ExecuteScalar());
-                        Console.WriteLine(result); // prints 1
-                    }
-                }
+	            TestDatabaseCreation
+            };
+
+            using var fixture = ThrowawayDatabase.FromLocalInstance(ConnectionString);
+
+            for (var i = 0; i < testCases.Length; i++)
+            {
+	            Console.WriteLine("Running test #{0}: {1}", i + 1, testCases[i].Method.Name);
+	            testCases[i](fixture);
             }
         }
+
+	    private static void TestDatabaseCreation(ThrowawayDatabase fixture)
+	    {
+		    Console.WriteLine($"Created database {fixture.Name}");
+		    
+		    // Apply migrations / seed data if necessary
+		    // execute code against this newly generated database
+		    using var connection = new SqlConnection(fixture.ConnectionString);
+		    connection.Open();
+		    
+		    using var cmd = new SqlCommand("SELECT 1", connection);
+		    var result = Convert.ToInt32(cmd.ExecuteScalar());
+		    Console.WriteLine(result); // prints 1
+	    }
     }
 }

--- a/tests/ThrowawayDb/Program.cs
+++ b/tests/ThrowawayDb/Program.cs
@@ -22,7 +22,9 @@ namespace tests
 			var testCases = new Action[]
 			{
 				CreateDatabase,
-				CreateAndRestoreSnapshot
+				CreateAndRestoreSnapshot,
+				CreateSnapshotOnlyOnce,
+				NotRestoreSnapshotIfNotCreated
 			};
 
 			for (var i = 0; i < testCases.Length; i++)
@@ -117,7 +119,7 @@ namespace tests
 
 			items = GetItems(fixture).ToArray();
 			Console.WriteLine("Items before restore: {0}", FormatItems(items));
-			items.Should().BeEquivalentTo(new[] {1, 2, 3});
+			items.Should().BeEquivalentTo(new[] { 1, 2, 3 });
 
 			// Restore the snapshot
 			fixture.RestoreSnapshot();
@@ -136,6 +138,28 @@ namespace tests
 				while (reader.Read() && reader.HasRows)
 					yield return reader.GetInt32(0);
 			}
+		}
+
+		private static void CreateSnapshotOnlyOnce()
+		{
+			using var fixture = CreateFixture();
+
+			foreach (var i in Enumerable.Range(1, 3))
+			{
+				Console.WriteLine("Creating a snapshot: {0}", i);
+				fixture.CreateSnapshot();
+			}
+
+			Console.WriteLine("Restoring the snapshot");
+			fixture.RestoreSnapshot();
+		}
+
+		private static void NotRestoreSnapshotIfNotCreated()
+		{
+			using var fixture = CreateFixture();
+
+			Console.WriteLine("Restoring a snapshot which does not exist");
+			fixture.RestoreSnapshot();
 		}
 	}
 }

--- a/tests/ThrowawayDb/Tests.csproj
+++ b/tests/ThrowawayDb/Tests.csproj
@@ -1,17 +1,17 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-    <LangVersion>preview</LangVersion>
-  </PropertyGroup>
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>netcoreapp2.0</TargetFramework>
+		<LangVersion>preview</LangVersion>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="System.Data.SqlClient" Version="4.6.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="FluentAssertions" Version="5.10.3" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\ThrowawayDb\ThrowawayDb.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\src\ThrowawayDb\ThrowawayDb.csproj" />
+	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Refactored the old code a bit (renamed fields to match usual c# conventions, inverted some ifs to reduce nesting, removed unused variables)
- Added methods `CreateSnapshot()` and `RestoreSnapshot()`, as well as a cleanup step in `Dispose()` if a snapshot is created.
- Added public extension methods for opening a new connection: `OpenConnection()` and `OpenConnectionAsync(CancellationToken ct)`
- Added an internal extension method for terminating SQL connections
