### PR TITLE
Add extension method on ThrowawayDatabase to create a Snapshot scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,15 @@ database.CreateSnapshot();
 // execute some other actions which modify the database
 database.RestoreSnapshot();
 ```
+A snapshot can also be created as a snapshot scope. This way you ensure that the RestoreSnapshot method is always called.
+```cs
+using var database = ThrowawayDatabase.FromLocalInstance("localhost\\SQLEXPRESS");
+
+using(var scope = database.CreateSnapshotScope())
+{
+    // execute actions that modifies the database, and that should only last inside this scope.
+}
+```
 
 ## Using PostgreSQL server
 Install `ThrowawayDb.Postgres` from Nuget

--- a/src/ThrowawayDb/SnapshotScope.cs
+++ b/src/ThrowawayDb/SnapshotScope.cs
@@ -4,18 +4,18 @@ namespace ThrowawayDb
 {
     public class SnapshotScope : IDisposable
     {
-        private ThrowawayDatabase _db;
+        public ThrowawayDatabase Db { get; private set; }
 
         public SnapshotScope(ThrowawayDatabase db)
         {
-            _db = db;
-            _db.CreateSnapshot();
+            Db = db;
+            Db.CreateSnapshot();
         }
 
         public void Dispose()
         {
-            _db?.RestoreSnapshot();
-            _db = null;
+            Db?.RestoreSnapshot();
+            Db = null;
         }
     }
 }

--- a/src/ThrowawayDb/SnapshotScope.cs
+++ b/src/ThrowawayDb/SnapshotScope.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace ThrowawayDb
+{
+    public class SnapshotScope : IDisposable
+    {
+        private ThrowawayDatabase _db;
+
+        public SnapshotScope(ThrowawayDatabase db)
+        {
+            _db = db;
+            _db.CreateSnapshot();
+        }
+
+        public void Dispose()
+        {
+            _db?.RestoreSnapshot();
+            _db = null;
+        }
+    }
+}

--- a/src/ThrowawayDb/ThrowawayDatabaseExtensions.cs
+++ b/src/ThrowawayDb/ThrowawayDatabaseExtensions.cs
@@ -34,5 +34,15 @@ namespace ThrowawayDb
 
 			return connection;
 		}
+
+		/// <summary>
+		/// Creates a snapshot at the beginning of the scope, and restores the snapshot at the end of the scope.
+		/// </summary>
+		/// <param name="this">An instance of <see cref="ThrowawayDatabase"/></param>
+		/// <returns>The <see cref="SnapshotScope"/></returns>
+		public static SnapshotScope CreateSnapshotScope(this ThrowawayDatabase @this)
+        {
+            return new SnapshotScope(@this);
+        }
 	}
 }


### PR DESCRIPTION
Hi

Great library and just what I was looking for to make integration tests.
I have added a new SnapshotScope, that implements IDisposable. It basically makes shure that RestoreSnapshot is called at the end of the scope.
I have also added an extension method on the ThrowawayDatabase class to make it easier to create the scope.
